### PR TITLE
Bug in domChange listener

### DIFF
--- a/jquery.linearnavigation.js
+++ b/jquery.linearnavigation.js
@@ -104,7 +104,6 @@
                 };
 
                 var onDomChange = function() {
-                    currentItemIndex = null;
                     $collection = $widget.find(itemsSelector);
                     numItems = $collection.length;
 
@@ -113,6 +112,7 @@
                     $widget.trigger('linearNavigationItemsChange');
 
                     if (options.autoInitOnDomChange === true) {
+                        currentItemIndex = null;
                         initModel();
                     }
                 };

--- a/jquery.linearnavigation.js
+++ b/jquery.linearnavigation.js
@@ -104,6 +104,7 @@
                 };
 
                 var onDomChange = function() {
+                    currentItemIndex = null;
                     $collection = $widget.find(itemsSelector);
                     numItems = $collection.length;
 


### PR DESCRIPTION
When the dom changes, the currentItemIndex is set to 0 instead of its initial value of null.  This means the code in initModel doesn't get run, since currentItemIndex is set to the default active index.

Ian, this fixes the following internal bug:
https://jirap.corp.ebay.com/browse/MTRSEXP-1250

I can give you more details if you want.  I can't find a better fix for it.

Also, please make the same fix in the non-jQuery version.  I haven't updated to that yet, but hope to soon.
